### PR TITLE
[#2] Don't set AWS_PROFILE env var

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ fabric.properties
 *.out
 .glide/
 portray-*
+portray

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ help:
 build:
 	go get github.com/aws/aws-sdk-go
 	@echo "Building portray for your current environment"
-	go build main.go -o portray
+	go build -o portray main.go
 
 build_multi:
 	go get github.com/aws/aws-sdk-go

--- a/main.go
+++ b/main.go
@@ -44,7 +44,7 @@ func main() {
 	}
 
 	profile := "default"
-	envProfile := os.Getenv("AWS_PROFILE")
+	envProfile := os.Getenv("PORTRAY_PROFILE")
 	fileName := ""
 	roleFileName := ""
 
@@ -189,7 +189,13 @@ func main() {
 			}
 			writePortrayConfigToFile(portrayConfigFileName, config)
 		}
-		startShell(roleAccountNumber + "-" + *roleNamePtr)
+		sessionName := ""
+		if *roleNamePtr == "" {
+			sessionName := roleAccountNumber + "-" + roleName
+		} else {
+			sessionName := roleAccountNumber + "-" + *roleNamePtr
+		}
+		startShell(sessionName)
 	}
 }
 

--- a/main.go
+++ b/main.go
@@ -63,7 +63,7 @@ func main() {
 		authCommand.Parse(os.Args[2:])
 		if *profilePtr != "" {
 			profile = *profilePtr
-			os.Setenv("AWS_PROFILE", profile)
+			os.Setenv("PORTRAY_PROFILE", profile)
 		} else if envProfile != "" {
 			profile = envProfile
 		} else if config.DefaultProfile != "" {
@@ -74,7 +74,7 @@ func main() {
 		switchCommand.Parse(os.Args[2:])
 		if *profilePtr != "" {
 			profile = *profilePtr
-			os.Setenv("AWS_PROFILE", profile)
+			os.Setenv("PORTRAY_PROFILE", profile)
 		} else if envProfile != "" {
 			profile = envProfile
 		} else if config.DefaultProfile != "" {
@@ -291,7 +291,7 @@ func sessionToEnvVars(awsCreds AwsCreds, account string, role string, profile st
 	}
 
 	fmt.Println("Setting ENV VARS")
-	os.Setenv("AWS_PROFILE", profile)
+	os.Setenv("PORTRAY_PROFILE", profile)
 	os.Setenv("AWS_ACCESS_KEY_ID", awsCreds.AccessKeyID)
 	os.Setenv("AWS_SECRET_ACCESS_KEY", awsCreds.SecretAccessKey)
 	os.Setenv("AWS_SESSION_TOKEN", awsCreds.SessionToken)


### PR DESCRIPTION
Change the AWS_PROFILE env var we're setting in the shell after auth and switch commands to PORTRAY_PROFILE.

This also fixes a syntax error in the `make build` command, as well as the session name output not rendering the role name when using saved profiles.

Address #2.