### PR TITLE
Add config command to parse AWS config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+*.sw[p|o]
+*.yaml
+*.json
+portray

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,47 @@
+# Colors
+NOCOLOR=\033[0m
+RED=\033[0;31m
+GREEN=\033[0;32m
+
+clean:
+	@go clean
+
+build:
+	@echo "Building project"
+	@go build && echo "${GREEN}Success!${NOCOLOR}" || echo "${RED}Build failed!${NOCOLOR}";
+
+debug_in_tmux_pane:
+	@echo "Launching delve debugger in bottom-right tmux pane"
+	@if pgrep dlv >/dev/null 2>&1; then killall dlv; fi
+	@tmux send-keys -t bottom-right 'echo "Magic launching Delve debugger"' Enter
+	@tmux send-keys -t bottom-right 'dlv exec portray -- ${PORTRAY_ARGS}' ENTER
+
+exec_in_tmux_pane:
+	@echo "Executing in bottom-right tmux pane"
+	@if pgrep dlv >/dev/null 2>&1; then killall dlv; fi
+	@tmux send-keys -t bottom-right './portray ${PORTRAY_ARGS}' ENTER
+
+execloop:
+	@echo "Starting file watcher"
+	@fswatch --exclude='.*\.git' \
+    --exclude='test\.yaml' \
+	--exclude='.*\.swp' \
+	--exclude='.*\debug.*?' \
+	--exclude='.*4913' \
+	--exclude='Makefile' \
+	--exclude='LICENSE' \
+	--exclude='.*/portray/portray' \
+	--recursive . | \
+	xargs -n1 -I{} sh -c 'echo "Change detected: {}"; make clean; make build; if [ -f portray ]; then make exec_in_tmux_pane PORTRAY_ARGS="${PORTRAY_ARGS}"; fi'
+
+debugloop:
+	@echo "Starting file watcher"
+	@fswatch --exclude='.*\.git' \
+	--exclude='.*\.swp' \
+	--exclude='.*\debug.*?' \
+	--exclude='.*4913' \
+	--exclude='Makefile' \
+	--exclude='LICENSE' \
+	--exclude='.*/portray/portray' \
+	--recursive . | \
+	xargs -n1 -I{} sh -c 'echo "Change detected: {}"; make clean; make build; if [ -f portray ]; then make debug_in_tmux_pane PORTRAY_ARGS="${PORTRAY_ARGS}"; fi'

--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,8 @@ exec_in_tmux_pane:
 execloop:
 	@echo "Starting file watcher"
 	@fswatch --exclude='.*\.git' \
-    --exclude='test\.yaml' \
+    --exclude='.*\.yaml' \
+    --exclude='.*\.json' \
 	--exclude='.*\.swp' \
 	--exclude='.*\debug.*?' \
 	--exclude='.*4913' \
@@ -37,6 +38,8 @@ execloop:
 debugloop:
 	@echo "Starting file watcher"
 	@fswatch --exclude='.*\.git' \
+    --exclude='.*\.yaml' \
+    --exclude='.*\.json' \
 	--exclude='.*\.swp' \
 	--exclude='.*\debug.*?' \
 	--exclude='.*4913' \

--- a/cmd/auth.go
+++ b/cmd/auth.go
@@ -141,6 +141,7 @@ func init() {
 	authCmd.Flags().StringVarP(&tokenCode, "token", "t", "", "an MFA token")
 	authCmd.Flags().StringVarP(&profile, "profile", "p", "", "a name for your profile")
 	authCmd.Flags().BoolP("no-mfa", "n", false, "disable MFA")
+
 	viper.BindPFlag("noMfa", authCmd.Flags().Lookup("no-mfa"))
 }
 

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -1,0 +1,190 @@
+// Copyright © 2017 Jason Myers <jason@mailthemyers.com>
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package cmd
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+    "strconv"
+	"strings"
+
+    "github.com/ghodss/yaml"
+	"github.com/go-ini/ini"
+	homedir "github.com/mitchellh/go-homedir"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+)
+
+type PortrayConfig struct {
+    DefaultProfile   string           `json:default_profile`
+    DefaultAccountId int              `json:default_account_id`
+    AuthProfiles     []AwsAuthProfile `json:auth_profiles`
+    Profiles         []AwsRoleProfile `json:profiles`
+//    AuthProfiles map[string]map[string]AwsAuthProfile `json:source_profiles`
+//    Profiles       map[string]map[string]AwsRoleProfile   `json:profiles`
+}
+
+type AwsAuthProfile struct {
+	Name      string `json:name`
+    AccountId int    `json:account_id`
+    UserName  string `json:user_name`
+	Region    string `json:region`
+	Output    string `json:output`
+}
+
+type AwsRoleProfile struct {
+	Name          string `json:name`
+	SourceProfile string `json:source_profile`
+	RoleName      string `json:role_name`
+	MfaSerial     string `json:mfa_serial`
+	ExternalId    string `json:external_id`
+}
+
+// configCmd represents the sync command
+var configCmd = &cobra.Command{
+	Use:   "config",
+	Short: "manage the Portray config",
+	Long:  `The config command allows you to view the current Portray config,
+as well as sync it with the AWS CLI config`,
+	Run: func(cmd *cobra.Command, args []string) {
+		err := viper.ReadInConfig() // Find and read the config file
+        check(err)
+
+        if viper.GetBool("sync") {
+            fmt.Println("Attempting to parse ~/.aws/config")
+		    parseAwsConfig()
+        } else {
+            fmt.Println("Bare config command not yet implemented. Try --sync")
+        }
+	},
+}
+
+func init() {
+	RootCmd.AddCommand(configCmd)
+
+	configCmd.Flags().BoolP("sync", "s", false, "sync Portray config with AWS CLI")
+    viper.BindPFlag("sync", configCmd.Flags().Lookup("sync"))
+}
+
+func parseAwsConfig() {
+	home, err := homedir.Dir()
+	if err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
+	cfg, err := ini.Load(home + "/.aws/config")
+	if err != nil {
+		fmt.Println(err.Error())
+		os.Exit(1)
+	}
+
+    // ini parsing has a DEFAULT section that's empty. Let's not count it.
+	numProfiles := len(cfg.SectionStrings()) - 1
+	fmt.Printf("Found %d profiles in AWS config\n", numProfiles)
+
+    portrayConfig   := PortrayConfig{}
+    awsAuthProfiles := []AwsAuthProfile{}
+    awsRoleProfiles := []AwsRoleProfile{}
+
+	for i := 0; i < numProfiles; i++ {
+        sectionHeader := cfg.SectionStrings()[i]
+        // skip empty DEFAULT section
+        if sectionHeader == "DEFAULT" {
+            continue
+        } else if sectionHeader == "default" {
+            // Found default profile
+            portrayConfig.DefaultProfile = "default"
+        }
+
+        sectionHash := cfg.Section(sectionHeader).KeysHash()
+        profileName := strings.Replace(sectionHeader, "profile ", "", 1)
+
+        // Parse out the profiles that don't have a source_profile defined
+        // and assume they're a source profile that has credentials.
+        if sectionHash["source_profile"] == "" {
+            var profile AwsAuthProfile
+
+            profile.Name      = profileName
+            profile.Region    = sectionHash["region"] 
+            profile.Output    = sectionHash["output"] 
+            awsAuthProfiles = append(awsAuthProfiles, profile)
+        } else {
+            var profile AwsRoleProfile
+
+            profile.Name          = profileName
+	        profile.SourceProfile = sectionHash["source_profile"]
+	        profile.RoleName      = strings.Split(sectionHash["role_arn"], "/")[1]
+	        profile.MfaSerial     = sectionHash["mfa_serial"]
+	        profile.ExternalId    = sectionHash["external_id"]
+            awsRoleProfiles       = append(awsRoleProfiles, profile)
+        }
+	}
+
+    numAuthProfiles := len(awsAuthProfiles)
+    numRoleProfiles   := len(awsRoleProfiles)
+    // For every source profile, let's loop through the role profiles looking
+    // for any references to an MFA devices so we can infer account id and
+    // username for the source profiles.
+	for i := 0; i < numAuthProfiles; i++ {
+        profileName := awsAuthProfiles[i].Name
+            
+        for x := 0; x < numRoleProfiles; x++ {
+            sourceProfile := awsRoleProfiles[x].SourceProfile
+            if sourceProfile == profileName {
+                // grab username from MFA ARN
+                userName  := strings.Split(awsRoleProfiles[x].MfaSerial, "/")[1]
+                accountId := strings.Split(awsRoleProfiles[x].MfaSerial, ":")[4]
+                awsAuthProfiles[x].UserName  = userName
+                awsAuthProfiles[x].AccountId, err = strconv.Atoi(accountId)
+                check(err)
+
+                if sourceProfile == "default" {
+                    portrayConfig.DefaultProfile   = "default"
+                    portrayConfig.DefaultAccountId = awsAuthProfiles[x].AccountId
+                }
+                break
+            }
+        }
+    }
+
+    portrayConfig.AuthProfiles = awsAuthProfiles
+    portrayConfig.Profiles = awsRoleProfiles
+
+	// convert to yaml
+    yamlData, err := yaml.Marshal(portrayConfig)
+	check(err)
+    // convert to json
+    jsonData, err := yaml.YAMLToJSON(yamlData)
+	check(err)
+
+    // dump yaml to file
+	err = ioutil.WriteFile("test.yaml", yamlData, 0644)
+	check(err)
+    // dump json to file
+	err = ioutil.WriteFile("test.json", jsonData, 0644)
+	check(err)
+}
+	
+func check(e error) {
+	if e != nil {
+		panic(e)
+	}
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -34,7 +34,7 @@ var cfgFile string
 var RootCmd = &cobra.Command{
 	Use:   "portray",
 	Short: "An AWS session and role management tool",
-	Long:  `Portray helps manage STS sessions in multiple accounts by
+	Long: `Portray helps manage STS sessions in multiple accounts by
 isolating temporary credentials into subshells.`,
 }
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -33,12 +33,9 @@ var cfgFile string
 // RootCmd represents the base command when called without any subcommands
 var RootCmd = &cobra.Command{
 	Use:   "portray",
-	Short: "An AWS role management tool",
-	Long: `Portray allows you to assume roles that require MFA in multiple
-	accounts.`,
-	// Uncomment the following line if your bare application
-	// has an action associated with it:
-	//	Run: func(cmd *cobra.Command, args []string) { },
+	Short: "An AWS session and role management tool",
+	Long:  `Portray helps manage STS sessions in multiple accounts by
+isolating temporary credentials into subshells.`,
 }
 
 // Execute adds all child commands to the root command and sets flags appropriately.
@@ -54,7 +51,6 @@ func init() {
 	cobra.OnInitialize(initConfig)
 
 	RootCmd.PersistentFlags().StringVar(&cfgFile, "config", "", "config file (default is $HOME/.portray.yaml)")
-
 }
 
 // initConfig reads in config file and ENV variables if set.
@@ -71,7 +67,9 @@ func initConfig() {
 		}
 
 		// Search config in home directory with name ".portray" (without extension).
+		viper.AddConfigPath("/etc/portray/")
 		viper.AddConfigPath(home)
+		viper.AddConfigPath(".")
 		viper.SetConfigName(".portray")
 	}
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -77,6 +77,6 @@ func initConfig() {
 
 	// If a config file is found, read it in.
 	if err := viper.ReadInConfig(); err == nil {
-		fmt.Println("Using config file:", viper.ConfigFileUsed())
+		//fmt.Println("Using config file:", viper.ConfigFileUsed())
 	}
 }

--- a/cmd/switch.go
+++ b/cmd/switch.go
@@ -32,8 +32,8 @@ var profileName string
 var switchCmd = &cobra.Command{
 	Use:   "switch",
 	Short: "assumes an AWS role",
-	Long: `The switch command allows you to asumme a role, and save the details
-	to make it easier to assume it again later`,
+	Long:  `The switch command allows you to assume a role via a named profile
+or by passing in the account and role details directly.`,
 	Run: func(cmd *cobra.Command, args []string) {
 		fmt.Println("switch called")
 	},
@@ -42,7 +42,7 @@ var switchCmd = &cobra.Command{
 func init() {
 	RootCmd.AddCommand(switchCmd)
 
-	switchCmd.Flags().StringVarP(&accountNumber, "account", "a", "", "the AWS account number")
+	switchCmd.Flags().StringVarP(&accountId, "account", "a", "", "the AWS account number")
 	switchCmd.Flags().StringVarP(&role, "role", "r", "", "the AWS role to assume")
 	switchCmd.Flags().StringVarP(&profileName, "profile", "p", "", "the name to save these details under")
 	switchCmd.Flags().StringVarP(&userName, "username", "u", "", "the AWS user name")

--- a/cmd/switch.go
+++ b/cmd/switch.go
@@ -32,7 +32,7 @@ var profileName string
 var switchCmd = &cobra.Command{
 	Use:   "switch",
 	Short: "assumes an AWS role",
-	Long:  `The switch command allows you to assume a role via a named profile
+	Long: `The switch command allows you to assume a role via a named profile
 or by passing in the account and role details directly.`,
 	Run: func(cmd *cobra.Command, args []string) {
 		fmt.Println("switch called")


### PR DESCRIPTION
> Disclaimer: This is all still experimental, so I've built it off your Cobra branch. This is the most Golang I've ever written, so no tests yet, but it does seem to be working.

This tackles both #4 and #5.

## Dependency Changes

Unfortunately viper can't parse INI files yet, and the YAML library assists with marshaling from INI to YAML or JSON.

- Adds `github.com/go-ini/ini`
- Adds `github.com/ghodss/yaml`

## Changes

This adds a `portray config --sync` command that by default will parse the AWS config and dump it to stdout in YAML format. You can also pass a `--out-file/-o` flag to write the data to a file, as well as a `--format/-f` to alternately specify JSON format.

I've updated the config format to be map- instead of list-based, and the auth command has been updated to read from it.

I've also added a Makefile with an [fswatch](https://github.com/emcrisostomo/fswatch) file watcher that hooks into Delve and Tmux.

## Other Tweaks

- Initial work to allow multiple auth profiles to be defined and used for the `portray auth` command. This is there in the config, but `auth/getNewSession()` needs to be updated to work with the `--profile` flag
- Make MFA prompting optional since not all accounts will force MFA. Added `--no-mfa/-n` flag to the auth command.
- go fmt and other refactorings