### PR TITLE
set AWS_SECURITY_TOKEN for boto2 software

### DIFF
--- a/util/root.go
+++ b/util/root.go
@@ -186,6 +186,7 @@ func SessionToEnvVars(awsCreds AwsCreds, account string, role string, profile st
 	fmt.Println("Setting ENV VARS")
 	os.Setenv("AWS_ACCESS_KEY_ID", awsCreds.AccessKeyID)
 	os.Setenv("AWS_SECRET_ACCESS_KEY", awsCreds.SecretAccessKey)
+	os.Setenv("AWS_SECURITY_TOKEN", awsCreds.SessionToken)
 	os.Setenv("AWS_SESSION_TOKEN", awsCreds.SessionToken)
 	os.Setenv("PORTRAY_PROMPT", prompt)
 }


### PR DESCRIPTION
boto2 used `$AWS_SECURITY_TOKEN` (boto3 has since switched to the standard `$AWS_SESSION_TOKEN`). But boto2 software is still in the wild, so it would be nice to set that environment variable as well.