### PR TITLE
Add version command and build-time version info

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,10 @@
 # Makefile to help with building portray
 #
 BUILD_VERSION:=$(shell git describe --tags)
-LDFLAGS=-ldflags "-X main.version=${BUILD_VERSION}"
+GIT_COMMIT := $(shell git rev-parse HEAD)
+BUILD_TIME := $(shell TZ=utc date)
+GO_VERSION := $(shell go version | sed 's/go version //')
+LDFLAGS=-ldflags "-X main.Version=${BUILD_VERSION} -X main.GitCommit=${GIT_COMMIT} -X \"main.BuildTime=${BUILD_TIME}\" -X \"main.GoVersion=${GO_VERSION}\""
 
 # Colors
 NOCOLOR=\033[0m
@@ -21,16 +24,16 @@ clean:
 build:
 	go get
 	@echo "Building portray for your current environment"
-	@go build && echo "${GREEN}Success!${NOCOLOR}" || echo "${RED}Build failed!${NOCOLOR}";
+	go build ${LDFLAGS} && echo "${GREEN}Success!${NOCOLOR}" || echo "${RED}Build failed!${NOCOLOR}";
 
 build_multi:
 	go get
 	@echo "Building portray for Linux amd64"
-	GOOS=linux GOARCH=amd64 go build -o portray-linux-amd64 main.go
+	GOOS=linux GOARCH=amd64 go build ${LDFLAGS} -o portray-linux-amd64 main.go
 	@echo "Building portray for Mac OS X amd64"
-	GOOS=darwin GOARCH=amd64 go build -o portray-mac-amd64 main.go
+	GOOS=darwin GOARCH=amd64 go build ${LDFLAGS} -o portray-mac-amd64 main.go
 	@echo "Building portray for Windows amd64"
-	GOOS=windows GOARCH=amd64 go build -o portray-windows-amd64 main.go
+	GOOS=windows GOARCH=amd64 go build ${LDFLAGS} -o portray-windows-amd64 main.go
 
 debug_in_tmux_pane:
 	@echo "Launching delve debugger in bottom-right tmux pane"

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,7 @@
 # Makefile to help with building portray
 #
+BUILD_VERSION:=$(shell git describe --tags)
+LDFLAGS=-ldflags "-X main.version=${BUILD_VERSION}"
 
 # Colors
 NOCOLOR=\033[0m

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -31,6 +31,14 @@ import (
 var cfgFile string
 var debug bool
 
+// compile time build info
+var (
+	Version   string
+	GitCommit string
+	BuildTime string
+	GoVersion string
+)
+
 // rootCmd represents the base command when called without any subcommands
 var rootCmd = &cobra.Command{
 	Use:   "portray",

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -17,24 +17,36 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-package main
+package cmd
 
-import "github.com/jasonamyers/portray/cmd"
+import (
+	"fmt"
 
-// compile time build info
-var (
-	Version   string
-	GitCommit string
-	BuildTime string
-	GoVersion string
+	"github.com/spf13/cobra"
 )
 
-func main() {
-	// Set built-time vars in the cmd package so we can access them in commands
-	cmd.Version = Version
-	cmd.GitCommit = GitCommit
-	cmd.BuildTime = BuildTime
-	cmd.GoVersion = GoVersion
+// configCmd represents the sync command
+var versionCmd = &cobra.Command{
+	Use:   "version",
+	Short: "display Portray version info",
+	Long: `The version command allows you to view information about the current
+Portray version`,
+	Run: func(cmd *cobra.Command, args []string) {
 
-	cmd.Execute()
+		// Print the version info
+		versionInfo := fmt.Sprintf(`Portray build info:
+
+  Version:	%s
+  Git Commit:	%s
+  Build Time:	%s
+  Go Version:	%s
+
+`, Version, GitCommit, BuildTime, GoVersion)
+
+		fmt.Print(versionInfo)
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(versionCmd)
 }

--- a/main.go
+++ b/main.go
@@ -21,6 +21,11 @@ package main
 
 import "github.com/jasonamyers/portray/cmd"
 
+var (
+    // compile time version string
+    version string
+)
+
 func main() {
 	cmd.Execute()
 }


### PR DESCRIPTION
Adds a `portray version` command. Passes build info to go compiler via LDFLAGS.

Sample output:

```
 $ portray version
Portray build info:

  Version:      v1.0-33-g4358097
  Git Commit:   4358097b3ed1c172b2c4e83242bec25cc1548ee6
  Build Time:   Mon Apr 16 16:23:07 UTC 2018
  Go Version:   go1.10 darwin/amd64
```

Fixes #13.